### PR TITLE
Execute reload cmd when a new folder is created

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016-2018 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ setup:
 
 install:
 	@go version
-	export GO15VENDOREXPERIMENT=1
+#	export GO15VENDOREXPERIMENT=1
 #	GOPATH=$(GOPATH) GOBIN=$(GOBIN) go install -v ./...
 	GOPATH=$(GOPATH) GOBIN=$(GOBIN) $(GOPATH)/bin/godep go install -v ./...
 

--- a/config-supervisor.go
+++ b/config-supervisor.go
@@ -62,7 +62,16 @@ func ParseFlags() {
 }
 
 func executeSyncCmd() {
-	go sync.Execute(*syncCmd)
+	//what if the previous command didn't finish ?
+	if status.LastSyncDuration < 0 {
+		log.Printf("Skipping sync as the previous command is still running ...")
+		return
+	}
+	go func(start time.Time) {
+		sync.Execute(*syncCmd)
+		status.LastSyncDuration = time.Since(start)
+	}(time.Now())
+	status.LastSyncDuration = -1
 	status.LastSync = time.Now()
 }
 

--- a/config-supervisor.go
+++ b/config-supervisor.go
@@ -9,9 +9,10 @@ import (
 	"runtime/pprof"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/adobe-apiplatform/api-gateway-config-supervisor/sync"
 	"github.com/adobe-apiplatform/api-gateway-config-supervisor/ws"
-	_ "net/http/pprof"
 
 	"github.com/carlescere/scheduler"
 
@@ -84,6 +85,7 @@ func watchForFSChanges() {
 	for {
 		select {
 		case file := <-c:
+			// log.Println(ansicolor.Blue("Changed:"), ansicolor.Underline(file))
 			if file == "" {
 				continue
 			}

--- a/config-supervisor_test.go
+++ b/config-supervisor_test.go
@@ -2,13 +2,19 @@ package main
 
 import (
 	"flag"
-	"github.com/adobe-apiplatform/api-gateway-config-supervisor/sync"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
+	Sync "sync"
 	"testing"
 	"time"
+
+	"github.com/adobe-apiplatform/api-gateway-config-supervisor/sync"
+	"github.com/koyachi/go-term-ansicolor/ansicolor"
 )
+
+var once Sync.Once
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -29,6 +35,12 @@ func setup(t *testing.T) (tempdir string) {
 	// setup extra debug information
 	debugOn := true
 	debug = &debugOn
+
+	once.Do(func() {
+		log.Println(ansicolor.IntenseBlack("Starting the main() program"))
+		go main()
+	})
+
 	return tmpDir
 }
 
@@ -51,9 +63,6 @@ func createFile(t *testing.T, tmpDir string, file_content string) (f *os.File, e
 func TestThatReloadCommandExecutesOnFsChanges(t *testing.T) {
 	tmpDir := setup(t)
 	defer os.RemoveAll(tmpDir)
-
-	// start the utility in background
-	go main()
 
 	status = sync.GetStatusInstance()
 	if time.Since(status.LastSync).Seconds() < 2 {
@@ -106,7 +115,6 @@ func TestThatReloadCommandExecutesOnFsChanges(t *testing.T) {
 
 	//reset the reload command
 	reload_cmd = "echo reload-cmd not defined"
-	reloadCmd = &reload_cmd
 }
 
 func TestThatSyncCommandExecutes(t *testing.T) {
@@ -118,17 +126,61 @@ func TestThatSyncCommandExecutes(t *testing.T) {
 	syncCmd = &sync_cmd_test
 
 	// wait for some time to init
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1100 * time.Millisecond)
 
-	// main is already started by the previous test
-	// and we can't start it here again due to: https://github.com/golang/go/issues/4674
-	//go main()
-
-	// wait for some time to init
-	time.Sleep(500 * time.Millisecond)
-
-	// check that the sync_cmd.txt file exists
+	// check that the sync_cmd.txt file was created when the sync command executes
 	if _, err := os.Stat(tmpDir + "/sync_cmd.txt"); err != nil {
 		t.Fatal("Expected to find the file created by the sync command " + tmpDir + "/sync_cmd.txt")
 	}
+
+	sync_cmd_test = "echo sync-cmd not defined"
+}
+
+func TestThatReloadCommandExecutesWhenNewFolderIsAdded(t *testing.T) {
+	tmpDir := setup(t)
+	defer os.RemoveAll(tmpDir)
+
+	// in order to test that the reload command executed, we create a file and later verify that it exists on the disk
+	reload_cmd_test := "touch " + tmpDir + "/reload_cmd.txt"
+	reloadCmd = &reload_cmd_test
+
+	syncFolder = &tmpDir
+	go watchForFSChanges()
+
+	// wait for some time
+	time.Sleep(500 * time.Millisecond)
+
+	//modifyFS: create a new directory and file
+	dir, err := ioutil.TempDir(tmpDir, "new-folder-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := createFile(t, dir, "new-file-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f2.Name()) // clean up
+
+	// wait for some time to track the changes
+	time.Sleep(1000 * time.Millisecond)
+
+	status = sync.GetStatusInstance()
+	// check that reload cmd has been executed
+	if time.Since(status.LastSync).Seconds() > 1 {
+		t.Fatal("sync should have executed earlier than 1.5 but was executed " + time.Since(status.LastSync).String())
+	}
+	if time.Since(status.LastReload).Seconds() > 1 {
+		t.Fatal("reload should have executed earlier than 1.5s but was executed " + time.Since(status.LastReload).String())
+	}
+	if time.Since(status.LastFSChangeDetected).Seconds() > 1 {
+		t.Fatal("FS changes should have been detected earlier than 1.5s but was detected " + time.Since(status.LastFSChangeDetected).String())
+	}
+
+	// check that the reload_cmd.txt file was created when the reload command executed
+	if _, err := os.Stat(tmpDir + "/reload_cmd.txt"); err != nil {
+		t.Fatal("Expected to find the file created by the reload command " + tmpDir + "/reload_cmd.txt")
+	}
+
+	//reset the reload command
+	reload_cmd_test = "echo reload-cmd not defined"
 }

--- a/config-supervisor_test.go
+++ b/config-supervisor_test.go
@@ -197,3 +197,32 @@ func TestThatReloadCommandExecutesWhenNewFolderIsAdded(t *testing.T) {
 	//reset the reload command
 	reload_cmd_test = "echo reload-cmd not defined"
 }
+
+func TestThatSyncCommandDoesntRunInParallel(t *testing.T) {
+	tmpDir := setup(t)
+	defer os.RemoveAll(tmpDir)
+
+	// in order to test that the sync command executed we create a file to later verify that it exists on the disk
+	sync_cmd_test := "sleep 3"
+	syncCmd = &sync_cmd_test
+
+	lastsync := status.LastSync
+
+	time.Sleep(1500 * time.Millisecond)
+
+	if status.LastSyncDuration != -1 {
+		t.Fatal("After 1.5s the sync command should not have finished.LastSyncDuration should have been -1")
+	}
+
+	if status.LastSync.Equal(lastsync) {
+		t.Fatal("Sync shouldn't have executed in the meanwhile.")
+	}
+
+	time.Sleep(1700 * time.Millisecond)
+
+	if time.Since(status.LastSync) < 3 {
+		t.Fatal("time since last sync is wrong: " + time.Since(status.LastSync).String())
+	}
+
+	sync_cmd_test = "echo sync-cmd not defined"
+}

--- a/config-supervisor_test.go
+++ b/config-supervisor_test.go
@@ -181,6 +181,19 @@ func TestThatReloadCommandExecutesWhenNewFolderIsAdded(t *testing.T) {
 		t.Fatal("Expected to find the file created by the reload command " + tmpDir + "/reload_cmd.txt")
 	}
 
+	//delete the tmp file and the TempDir
+	reload_cmd_test = "touch " + tmpDir + "/reload_cmd_after_rm.txt"
+	reloadCmd = &reload_cmd_test
+	// os.Remove(tmpDir + "/reload_cmd.txt")
+	os.RemoveAll(dir)
+
+	time.Sleep(3000 * time.Millisecond)
+
+	// check that the reload_cmd_after_rm.txt file was created when the reload command executed
+	if _, err := os.Stat(tmpDir + "/reload_cmd_after_rm.txt"); err != nil {
+		t.Fatal("Expected to find the file created by the reload command " + tmpDir + "/reload_cmd_after_rm.txt")
+	}
+
 	//reset the reload command
 	reload_cmd_test = "echo reload-cmd not defined"
 }

--- a/sync/recursiveWatcher.go
+++ b/sync/recursiveWatcher.go
@@ -95,6 +95,13 @@ func (watcher *RecursiveWatcher) Run(debug bool) {
 					watcher.Files <- event.Name
 				}
 
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
+					if debug {
+						DebugMessage("Detected remove event %s", event.Name)
+					}
+					watcher.Files <- event.Name
+				}
+
 			case err := <-watcher.fsw.Errors:
 				log.Println("error", err)
 			}

--- a/sync/status.go
+++ b/sync/status.go
@@ -10,6 +10,7 @@ type Status struct {
 	LastSync             time.Time `json:"lastSync"`
 	LastFSChangeDetected time.Time `json:"lastChangeDetected"`
 	LastReload           time.Time `json:"lastReload"`
+	LastSyncDuration     time.Duration
 }
 
 var instance *Status
@@ -20,6 +21,7 @@ func GetStatusInstance() *Status {
 		instance = &Status{
 			LastReload:           time.Now(), // we assume it has happened already to avoid immediate reloads
 			LastFSChangeDetected: time.Now(), // we assume it has happened already to avoid immediate reloads
+			LastSyncDuration:     0,
 		}
 	})
 	return instance

--- a/sync/watcher.go
+++ b/sync/watcher.go
@@ -1,8 +1,9 @@
 package sync
 
 import (
-	"github.com/koyachi/go-term-ansicolor/ansicolor"
 	"log"
+
+	"github.com/koyachi/go-term-ansicolor/ansicolor"
 )
 
 // Watches the specific folder for changes
@@ -20,10 +21,11 @@ func WatchFolderRecursive(folder string, debug bool) <-chan string {
 		for {
 			select {
 			case file := <-watcher.Files:
-				done <- file
 				log.Println(ansicolor.IntenseBlack("FS Changed"), ansicolor.Underline(file))
+				done <- file
 			case folder := <-watcher.Folders:
 				log.Println(ansicolor.Yellow("Watching path"), ansicolor.Yellow(folder))
+				done <- folder
 			}
 		}
 	}()


### PR DESCRIPTION
There are cases when a new folder is synced, it has config files in it, but the gateway doesn't reload. This happens b/c when a new folder is added it's only being _watched_ for changes or for new files, while the existing files in it are ignored. 
This is not a correct behavior; in the same way that a _new file_ causes a reload, _new directories_ should have the same effect; same behavior is expected for _remove_ events too.
